### PR TITLE
Replace grid with more efficient implementation

### DIFF
--- a/HaskellSweeper.cabal
+++ b/HaskellSweeper.cabal
@@ -12,6 +12,7 @@ cabal-version:      >=1.10
 
 library
   exposed-modules:  Sweeper.Grid
+                    Sweeper.Grid.BalancedTernary
                     Sweeper.Game
   build-depends:    base >=4.6 && <5
                   , containers

--- a/HaskellSweeper.hs
+++ b/HaskellSweeper.hs
@@ -108,9 +108,8 @@ doUpdate :: Window -> [ColorID] -> GameState -> Curses Score
 doUpdate w palette g@GameState{position=Cartesian x y, score, highscore, playState, options} = do
     updateWindow w $ do
         (sizeY, sizeX) <- windowSize
-        let (sizeX', sizeY') = (fromInteger sizeX, fromInteger sizeY)
-        let topLeft@(Cartesian left top) = Cartesian (x - (sizeX' `div` 2)) (y - (sizeY' `div` 2))
-        let bottomRight = Cartesian (left + sizeX' - 1) (top + sizeY' - 3)
+        let topLeft@(Cartesian left top) = Cartesian (x - (sizeX `div` 2)) (y - (sizeY `div` 2))
+        let bottomRight = Cartesian (left + sizeX - 1) (top + sizeY - 3)
         let panel = (topLeft, bottomRight)
 
         moveCursor 0 0
@@ -120,7 +119,7 @@ doUpdate w palette g@GameState{position=Cartesian x y, score, highscore, playSta
         drawLineH (Just glyphLineH) sizeX
         moveCursor (sizeY - 1) 0
         setColor $ palette!!0
-        drawString $ take (sizeX'-1) $
+        drawString $ take (fromInteger sizeX-1) $
             intercalate " | " (
                 prettyShow options ++
                 case playState of

--- a/src/Sweeper/Game.hs
+++ b/src/Sweeper/Game.hs
@@ -4,8 +4,8 @@
 module Sweeper.Game where
 
 import           Data.Hashable       (Hashable)
-import           Data.Set            (Set, delete, empty, insert, member, size)
 import           GHC.Generics        (Generic)
+import           Numeric.Natural
 import qualified Options.Applicative as Opt
 import           System.Random       (StdGen, randomR, split)
 
@@ -13,12 +13,29 @@ import           Prelude             hiding (Left, Right)
 
 import           Sweeper.Grid
 
-data Cell       = Empty | Mine deriving Eq
+data Cell       = Empty Bool | Mark Bool | Visible Int deriving Eq
 
--- | Set of positions (in the grid) that are visible (opened cell)
-type Visibility = Set Position
--- | Set of positions that are marked as containing a mine (wether or not it actually does)
-type Markers    = Set Position
+isMine :: Cell -> Bool
+isMine (Empty mine) = mine
+isMine (Mark  mine) = mine
+isMine _      = False
+
+isVisible :: Cell -> Bool
+isVisible Visible{} = True
+isVisible _         = False
+
+isMarked :: Cell -> Bool
+isMarked Mark{} = True
+isMarked _      = False
+
+mark :: Cell -> Cell
+mark (Empty mine) = Mark mine
+mark cell = cell
+
+unmark :: Cell -> Cell
+unmark (Mark mine) = Empty mine
+unmark cell = cell
+
 -- | The score corresponds to the sum of all the numbers showing in the visible cells
 type Score      = Int
 data PlayState  = Alive | Dead deriving Eq
@@ -47,8 +64,7 @@ data Move       = Up | Down | Left | Right | UpLeft | UpRight | DownLeft | DownR
 data GameState  = GameState
     {
         grid       :: Grid Cell,
-        visibility :: Visibility,
-        markers    :: Markers,
+        visible    :: Natural,
         score      :: Score,
         position   :: Position,
         highscore  :: Score,
@@ -60,17 +76,17 @@ data GameState  = GameState
 
 -- | Count the number of mines in the positions around a given position
 tallyMines :: Grid Cell -> Position -> Int
-tallyMines grid pos = length $ filter (==Mine) $ map (getCell grid) (surroundingPositions pos)
+tallyMines grid pos = length $ filter isMine $ map (`getCell` grid) (surroundingPositions pos)
 
--- | Count the number of markers in the positions around a given position
-tallyMarkers :: Markers -> Position -> Int
-tallyMarkers markers pos = length $ filter (`member` markers) (surroundingPositions pos)
+-- | Count the number of marked cells in the positions around a given position
+tallyMarkers :: Grid Cell -> Position -> Int
+tallyMarkers grid pos = length $ filter isMarked $ map (`getCell` grid) (surroundingPositions pos)
 
 -- | Randomly generate a cell given a density
 randomCell :: Int -> StdGen -> (Cell, StdGen)
 randomCell density gen =
   let (n, g) = randomR (0,99) gen
-  in (if n < density then Mine else Empty, g)
+  in (Empty (n < density), g)
 
 -- | Generate a random initial GameState
 createGameState :: StdGen -> Options -> Score -> GameState
@@ -78,8 +94,7 @@ createGameState gen opts hs = let (g, g') = split gen in
   GameState
     {
         grid       = randomGrid (randomCell (density opts)) g,
-        visibility = empty,
-        markers    = empty,
+        visible    = 0,
         position   = zeroPosition,
         score      = 0,
         highscore  = hs,
@@ -94,23 +109,23 @@ newGame GameState{randomgen=gen, options=opts, highscore=hs} = createGameState g
 
 -- | Recursively open cells that are empty (limited by panel to avoid infinite recursion)
 getEmptyCells :: GameState -> Position -> GameState
-getEmptyCells g@GameState{grid, panel, visibility, markers, score, highscore} pos
+getEmptyCells g@GameState{grid, visible, panel, score, highscore} pos
     | not (inBounds pos panel)
-      || member pos visibility
-      || member pos markers    = g
-    | t > 0                    = g{visibility=newVis, score=score + t, highscore=max highscore (score + t)}
-    | otherwise                = foldl getEmptyCells g{visibility=newVis} (surroundingPositions pos)
+      || isMarked (getCell pos grid)
+      || isVisible (getCell pos grid) = g
+    | t > 0                           = g{grid=newGrid, score=score + t, highscore=max highscore (score + t), visible=visible+1}
+    | otherwise                       = foldl getEmptyCells g{grid=newGrid} (surroundingPositions pos)
     where
         t :: Int
         t = tallyMines grid pos
 
-        newVis :: Visibility
-        newVis = insert pos visibility
+        newGrid :: Grid Cell
+        newGrid = setCell pos (Visible t) grid
 
 -- | A Cell (at a given position) is satisfied if the number of Mines around it matches the number of cells
 -- Markers could still be missplaced!
 isSatisfied :: GameState -> Position -> Bool
-isSatisfied GameState{grid, markers} p = tallyMines grid p == tallyMarkers markers p
+isSatisfied GameState{grid} p = tallyMines grid p == tallyMarkers grid p
 
 type GameUpdate = GameState -> Maybe GameState
 
@@ -118,7 +133,7 @@ type GameUpdate = GameState -> Maybe GameState
 --
 -- I don't know what's up with the patterns here... removing the ~'s incorrectly gives an incomplete pattern warning
 makeMove :: Move -> GameUpdate
-makeMove move g@GameState{grid, visibility, position, panel=(topLeft@ ~(Cartesian left top), bottomRight@ ~(Cartesian right bottom))} =
+makeMove move g@GameState{grid, position, panel=(topLeft@ ~(Cartesian left top), bottomRight@ ~(Cartesian right bottom))} =
     pure newGameState{position = movePosition dx dy position}
     where
         -- deltas from a Move
@@ -138,7 +153,7 @@ makeMove move g@GameState{grid, visibility, position, panel=(topLeft@ ~(Cartesia
         -- cells on the edge of the panel that need to be updated because the panel is moving
         -- this update is necessary since the cells opened recursively stopped at the edge of the panel
         cells :: [Position] 
-        cells = concatMap surroundingPositions $ filter (\p -> member p visibility && (tallyMines grid p == 0)) $ case move of
+        cells = concatMap surroundingPositions $ filter (\p -> isVisible (getCell p grid) && (tallyMines grid p == 0)) $ case move of
             Up        -> [Cartesian i top    | i <- [left..right]]
             Down      -> [Cartesian i bottom | i <- [left..right]]
             Left      -> [Cartesian left i   | i <- [top..bottom]]
@@ -153,12 +168,12 @@ makeMove move g@GameState{grid, visibility, position, panel=(topLeft@ ~(Cartesia
 
 -- | Implements the AutoOpen option by opening cells surrounding satisfied cells
 updateMarker :: Position -> GameUpdate
-updateMarker pos g@GameState{visibility=vis}
-    | size vis == size (visibility newGameState) = pure newGameState
-    | otherwise                                  = updateMarker pos newGameState
+updateMarker pos g@GameState{grid,visible=vn}
+    | vn == visible newGameState = pure newGameState
+    | otherwise                  = updateMarker pos newGameState
         where
             cells :: [Position]
-            cells = concatMap surroundingPositions $ filter (\p -> member p vis && isSatisfied g p) (surroundingPositions pos)
+            cells = concatMap surroundingPositions $ filter (\p -> isVisible (getCell p grid) && isSatisfied g p) (surroundingPositions pos)
 
             newGameState :: GameState
             newGameState = foldl clickCellPos g cells
@@ -166,14 +181,14 @@ updateMarker pos g@GameState{visibility=vis}
 -- | Handle the placement of a marker on the grid
 placeMarker :: GameUpdate
 placeMarker g@GameState{playState=Dead} = pure g
-placeMarker g@GameState{markers, visibility, position=pos, options}
-    | member pos visibility   = pure g
-    | member pos markers      = pure g{markers=delete pos markers}
+placeMarker g@GameState{grid, position=pos, options}
+    | isVisible (getCell pos grid) = pure g
+    | isMarked (getCell pos grid) = pure g{grid = modifyCell pos unmark grid}
     | autoOpen options        = updateMarker pos newGameState
     | otherwise               = pure newGameState
     where
         newGameState :: GameState
-        newGameState = g{markers=insert pos markers}
+        newGameState = g{grid = modifyCell pos mark grid}
 
 -- | Handle a player click on the current cell
 clickCell :: GameUpdate
@@ -182,13 +197,13 @@ clickCell g                           = pure $ clickCellPos g (position g)
 
 -- | Handle opening a cell (both user actions on automatic ones)
 clickCellPos :: GameState -> Position -> GameState
-clickCellPos g@GameState{grid, visibility=vis, markers} pos
-    | member pos markers       = g
-    | member pos vis           = updatedMarkers
-    | getCell grid pos == Mine = g{visibility=insert pos vis, playState=Dead}
-    | otherwise                = getEmptyCells g pos
+clickCellPos g@GameState{grid} pos
+    | isMarked (getCell pos grid)  = g
+    | isVisible (getCell pos grid) = updatedMarkers
+    | isMine (getCell pos grid)    = g{playState=Dead}
+    | otherwise                    = getEmptyCells g pos
     where
         updatedMarkers :: GameState
         updatedMarkers
-          | isSatisfied g pos = foldl clickCellPos g (filter (\p -> not $ member p vis) (surroundingPositions pos))
+          | isSatisfied g pos = foldl clickCellPos g (filter (\p -> not $ isVisible (getCell p grid)) (surroundingPositions pos))
           | otherwise         = g

--- a/src/Sweeper/Grid.hs
+++ b/src/Sweeper/Grid.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns    #-}
-module Sweeper.Grid (Grid, Position(Cartesian), zeroPosition, movePosition, Panel, getCell, surroundingPositions, inBounds, randomGrid) where
+module Sweeper.Grid (Grid, Position(Cartesian), zeroPosition, movePosition, Panel, getCell, surroundingPositions, inBounds, randomGrid, setCell, modifyCell) where
 
 import           System.Random (StdGen, split)
 
 import           Sweeper.Grid.BalancedTernary
 
 -- | Infinite 2D grid of cells
-data Grid a = Grid (Stream (Stream a))
+newtype Grid a = Grid (Stream (Stream a))
 
 -- | Position in the grid
 data Position = Position Index Index
@@ -31,8 +31,14 @@ type Panel = (Position, Position)
 
 -- Get a cell from the 2D infinite grid
 -- TODO: rename?
-getCell :: Grid a -> Position -> a
-getCell (Grid grid) (Position x y) = index (index grid x) y
+getCell :: Position -> Grid a  -> a
+getCell (Position x y) (Grid grid) = index y (index x grid)
+
+setCell :: Position -> a -> Grid a -> Grid a
+setCell (Position x y) a (Grid grid) = Grid $ update x (update y (const a)) grid
+
+modifyCell :: Position -> (a -> a) -> Grid a -> Grid a
+modifyCell (Position x y) f (Grid grid) = Grid $ update x (update y f) grid
 
 surroundingPositions :: Position -> [Position]
 surroundingPositions (Position x y) = [Position i j | i<-[pred x..succ x], j<-[pred y..succ y], x /= i || y /= j]

--- a/src/Sweeper/Grid.hs
+++ b/src/Sweeper/Grid.hs
@@ -1,13 +1,25 @@
-module Sweeper.Grid (Grid, Position, Panel, getCell, surroundingPositions, inBounds, randomGrid) where
+{-# LANGUAGE PatternSynonyms #-}
+module Sweeper.Grid (Grid, Position(Cartesian), zeroPosition, movePosition, Panel, getCell, surroundingPositions, inBounds, randomGrid) where
 
 import           Data.List     (unfoldr)
 import           System.Random (StdGen, split)
 
 -- | Infinite 2D grid of cells
-type Grid a = [[a]]
+newtype Grid a = Grid [[a]]
 
 -- | Position in the grid
-type Position = (Int, Int)
+data Position = Position Int Int
+  deriving (Eq, Ord)
+
+pattern Cartesian :: Int -> Int -> Position
+pattern Cartesian x y = Position x y
+{-# COMPLETE Cartesian #-}
+
+zeroPosition :: Position
+zeroPosition = Position 0 0
+
+movePosition :: Int -> Int -> Position -> Position
+movePosition dx dy (Position x y) = Position (x + dx) (y + dy)
 
 -- | The panel is used as limits for recursing down empty cells (it is supposed
 -- to be bigger than the terminal)
@@ -23,13 +35,13 @@ getIndex l i
 -- Get a cell from the 2D infinite grid
 -- TODO: rename?
 getCell :: Grid a -> Position -> a
-getCell grid (x, y) = getIndex (getIndex grid x) y
+getCell (Grid grid) (Position x y) = getIndex (getIndex grid x) y
 
 surroundingPositions :: Position -> [Position]
-surroundingPositions (x, y) = [(i, j) | i<-[x-1..x+1], j<-[y-1..y+1], x /= i || y /= j]
+surroundingPositions (Position x y) = [Position i j | i<-[x-1..x+1], j<-[y-1..y+1], x /= i || y /= j]
 
 inBounds :: Position -> Panel -> Bool
-inBounds (x, y) ((a, b), (c, d)) = a <= x && x <= c && b <= y && y <= d
+inBounds (Position x y) (Position a b, Position c d) = a <= x && x <= c && b <= y && y <= d
 
 randomGrid :: (StdGen -> (a, StdGen)) -> StdGen -> Grid a
-randomGrid f gen = [unfoldr (pure . f) g | g <- unfoldr (pure . split) gen]
+randomGrid f gen = Grid [unfoldr (pure . f) g | g <- unfoldr (pure . split) gen]

--- a/src/Sweeper/Grid.hs
+++ b/src/Sweeper/Grid.hs
@@ -1,47 +1,45 @@
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns    #-}
 module Sweeper.Grid (Grid, Position(Cartesian), zeroPosition, movePosition, Panel, getCell, surroundingPositions, inBounds, randomGrid) where
 
-import           Data.List     (unfoldr)
 import           System.Random (StdGen, split)
 
+import           Sweeper.Grid.BalancedTernary
+
 -- | Infinite 2D grid of cells
-newtype Grid a = Grid [[a]]
+data Grid a = Grid (Stream (Stream a))
 
 -- | Position in the grid
-data Position = Position Int Int
+data Position = Position Index Index
   deriving (Eq, Ord)
 
-pattern Cartesian :: Int -> Int -> Position
-pattern Cartesian x y = Position x y
+pattern Cartesian :: Integer -> Integer -> Position
+pattern Cartesian x y <- Position (fromIndex -> x) (fromIndex -> y)
+  where
+    Cartesian x y = Position (toIndex x) (toIndex y)
 {-# COMPLETE Cartesian #-}
 
 zeroPosition :: Position
-zeroPosition = Position 0 0
+zeroPosition = Position mempty mempty
 
-movePosition :: Int -> Int -> Position -> Position
-movePosition dx dy (Position x y) = Position (x + dx) (y + dy)
+movePosition :: Integer -> Integer -> Position -> Position
+movePosition dx dy (Position x y) = Position (x <> toIndex dx) (y <> toIndex dy)
 
 -- | The panel is used as limits for recursing down empty cells (it is supposed
 -- to be bigger than the terminal)
 type Panel = (Position, Position)
 
--- Get the index from an infinite list (infinite towards both -∞ and +∞)
--- List indices are like this: [0, 1, -1, 2, -2..]
-getIndex :: [a] -> Int -> a
-getIndex l i
-    | i <= 0    = l!!(-2*i)
-    | otherwise = l!!(2*i-1)
-
 -- Get a cell from the 2D infinite grid
 -- TODO: rename?
 getCell :: Grid a -> Position -> a
-getCell (Grid grid) (Position x y) = getIndex (getIndex grid x) y
+getCell (Grid grid) (Position x y) = index (index grid x) y
 
 surroundingPositions :: Position -> [Position]
-surroundingPositions (Position x y) = [Position i j | i<-[x-1..x+1], j<-[y-1..y+1], x /= i || y /= j]
+surroundingPositions (Position x y) = [Position i j | i<-[pred x..succ x], j<-[pred y..succ y], x /= i || y /= j]
 
 inBounds :: Position -> Panel -> Bool
-inBounds (Position x y) (Position a b, Position c d) = a <= x && x <= c && b <= y && y <= d
+inBounds (Cartesian x y) (Cartesian a b, Cartesian c d) = a <= x && x <= c && b <= y && y <= d
 
 randomGrid :: (StdGen -> (a, StdGen)) -> StdGen -> Grid a
-randomGrid f gen = Grid [unfoldr (pure . f) g | g <- unfoldr (pure . split) gen]
+randomGrid f gen = 
+  Grid $ randomStream (\g -> let (g0, g1) = split g in (randomStream f g0, g1)) gen

--- a/src/Sweeper/Grid/BalancedTernary.hs
+++ b/src/Sweeper/Grid/BalancedTernary.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Sweeper.Grid.BalancedTernary (Stream, index, Index, toIndex, fromIndex, randomStream) where
+
+import Data.Coerce
+import System.Random
+
+data Trit = T | O | I
+  deriving (Eq, Ord, Show)
+
+predTernary :: [Trit] -> [Trit]
+predTernary [] = [T]
+predTernary [I] = []
+predTernary (O:ns) = T:ns
+predTernary (I:ns) = O:ns
+predTernary (T:ns) = I:predTernary ns
+
+succTernary :: [Trit] -> [Trit]
+succTernary [] = [I]
+succTernary [T] = []
+succTernary (T:ns) = O:ns
+succTernary (O:ns) = I:ns
+succTernary (I:ns) = T:succTernary ns
+
+consO :: [Trit] -> [Trit]
+consO [] = []
+consO xs = O:xs
+
+plusTernary :: [Trit] -> [Trit] -> [Trit]
+plusTernary [] ns = ns
+plusTernary ms [] = ms
+plusTernary (T:ms) (O:ns) = T:plusTernary ms ns
+plusTernary (T:ms) (I:ns) = consO $ plusTernary ms ns
+plusTernary (O:ms) (O:ns) = consO $ plusTernary ms ns
+plusTernary (O:ms) (n:ns) = n:plusTernary ms ns
+plusTernary (I:ms) (T:ns) = consO $ plusTernary ms ns
+plusTernary (I:ms) (O:ns) = I:plusTernary ms ns
+plusTernary (T:ms) (T:ns) = predTernary $ T:plusTernary ms ns
+plusTernary (I:ms) (I:ns) = succTernary $ I:plusTernary ms ns
+
+toBalancedTernary :: Integer -> [Trit]
+toBalancedTernary 0 = []
+toBalancedTernary x = case x `divMod` 3 of
+  (q, 0) -> O : toBalancedTernary q
+  (q, 1) -> I : toBalancedTernary q
+  (q, 2) -> T : toBalancedTernary (q + 1)
+  _ -> error "Unreachable"
+
+fromBalancedTernary :: [Trit] -> Integer
+fromBalancedTernary [] = 0
+fromBalancedTernary (T:ns) = (-1) + 3 * fromBalancedTernary ns
+fromBalancedTernary (O:ns) =        3 * fromBalancedTernary ns
+fromBalancedTernary (I:ns) =   1  + 3 * fromBalancedTernary ns
+
+newtype Index = Index {getIndex :: [Trit]} -- invariant no trailing zeros
+  deriving (Eq, Ord)
+
+instance Semigroup Index where
+  (<>) = coerce plusTernary
+
+instance Monoid Index where
+  mempty = Index []
+
+instance Enum Index where
+  succ = coerce succTernary
+  pred = coerce predTernary
+  fromEnum = fromInteger . fromIndex
+  toEnum = toIndex . toInteger
+
+toIndex :: Integer -> Index
+toIndex = coerce toBalancedTernary
+
+fromIndex :: Index -> Integer
+fromIndex = coerce fromBalancedTernary
+
+-------------------------------------------------------------------------------
+
+data Nat = Z | S Nat
+
+data SNat n where
+  SZ :: SNat 'Z
+  SS :: SNat n -> SNat ('S n)
+
+data TernaryTree n a where
+  Leaf :: a -> TernaryTree 'Z a
+  Branch :: TernaryTree n a -> TernaryTree n a -> TernaryTree n a -> TernaryTree ('S n) a
+
+data CoTernaryTree n a where
+  CoTernaryTree :: TernaryTree n a -> CoTernaryTree ('S n) a -> TernaryTree n a -> CoTernaryTree n a
+
+-- | Skew balanced ternary skip stream
+data Stream a = Stream a (CoTernaryTree 'Z a)
+
+data Vec n a where
+  Nil :: Vec 'Z a
+  Cons :: a -> Vec n a -> Vec ('S n) a
+
+indexTernaryTree :: TernaryTree n a -> Vec n Trit -> a
+indexTernaryTree (Leaf a) Nil = a
+indexTernaryTree (Branch t o i) (Cons x n) = case x of
+  T -> indexTernaryTree t n
+  O -> indexTernaryTree o n
+  I -> indexTernaryTree i n
+
+indexCoTernaryTree :: CoTernaryTree n a -> Vec n Trit -> [Trit] -> a
+indexCoTernaryTree (CoTernaryTree _ _ _) _ [] = error "Unreachable"
+indexCoTernaryTree (CoTernaryTree t _ i) v [x] = case x of
+  T -> indexTernaryTree t v
+  O -> error "Unreachable"
+  I -> indexTernaryTree i v
+indexCoTernaryTree (CoTernaryTree _ o _) v (x:xs) = indexCoTernaryTree o (Cons x v) xs
+
+indexSBTSS :: Stream a -> [Trit] -> a
+indexSBTSS (Stream a _) [] = a
+indexSBTSS (Stream _ b) xs = indexCoTernaryTree b Nil xs
+
+index :: Stream a -> Index -> a
+index s = indexSBTSS s . getIndex
+
+randomStream :: forall a. (StdGen -> (a, StdGen)) -> StdGen -> Stream a
+randomStream f gen =
+  let (a, gen') = f gen
+  in Stream a $ randomCoTernaryTree gen' SZ
+  where
+    randomCoTernaryTree :: StdGen -> SNat n -> CoTernaryTree n a
+    randomCoTernaryTree g n =
+      let (g0, g1) = split g
+          (g2, g3) = split g0
+      in CoTernaryTree (randomTernaryTree g1 n) (randomCoTernaryTree g2 (SS n)) (randomTernaryTree g3 n)
+
+    randomTernaryTree :: StdGen -> SNat n -> TernaryTree n a
+    randomTernaryTree g SZ = Leaf . fst $ f g
+    randomTernaryTree g (SS n) =
+      let (g0, g1) = split g
+          (g2, g3) = split g0
+      in Branch (randomTernaryTree g1 n) (randomTernaryTree g2 n) (randomTernaryTree g3 n)


### PR DESCRIPTION
This:
* largely hides the implementation of the grid from the Game and Main modules
* uses a balanced ternary tree approach to represent the grid
* moves a lot of information (what's visible, for example), into the grid